### PR TITLE
Replaced java dependency with openjdk

### DIFF
--- a/hazelcast.rb
+++ b/hazelcast.rb
@@ -6,11 +6,11 @@ class Hazelcast < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk" => :recommended
 
   def install
     libexec.install Dir["*"]
-    bin.install_symlink Dir["#{libexec}/bin/hz"]
+    (bin/"hz").write_env_script libexec/"bin/hz", Language::Java.overridable_java_home_env
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
`openjdk` provides the latest OpenJDK version. It is `:recommended` in order to allow installing with `--without-openjdk` option. 