### PR TITLE
Add Hazelcast Cloud CLI Formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,33 @@
 
 `hz` is a tool which allows users to install & run [Hazelcast IMDG](https://hazelcast.org/imdg/) and [Management Center](https://hazelcast.org/imdg/download/#hazelcast-imdg-management-center) on local environment.
 
+`hzcloud` is a command line tool to make actions on Hazelcast Cloud easily
+
 ## About
 
-This repository contains the Homebrew formula for `hz`.
+This repository contains the Homebrew formula for `hz` and  `hzcloud`.
 
 See [Hazelcast Command Line](https://github.com/hazelcast/hazelcast-command-line/) for the source code.
 
+See [Hazelcast Cloud Command Line](https://github.com/hazelcast/hazelcast-cloud-cli) for the source code
+
 ## How to install
 
+### Tap repository
+
     $ brew tap hazelcast/hz
-    $ brew install hazelcast
+
+### Install Hazelcast CLI
+
+    $ brew install hazelcast 
+
+### Install Hazelcast CLoud CLI
+
+    $ brew install hzcloud 
 
 ### To clean up everything (may come in handy):
 
     $ brew uninstall hazelcast
+    $ brew uninstall hzcloud
     $ brew untap hazelcast/hz
     $ brew cleanup -s

--- a/hzcloud.rb
+++ b/hzcloud.rb
@@ -1,0 +1,20 @@
+class Hzcloud < Formula
+  desc "Hazelcast Cloud Enterprise is an enterprise-grade, on-demand managed service for Hazelcast IMDG"
+  homepage "http://cloud.hazelcast.com/"
+  url "https://github.com/hazelcast/hazelcast-cloud-cli/archive/v1.2.2.tar.gz"
+  sha256 "964b60f01149effca3074c1c3f83b2b1cf80bacf047d4a94b1c2177e9fa906c6"
+  depends_on "go" => :build
+  
+  def install
+      ENV["GOPATH"] = buildpath
+      bin_path = buildpath/"src/github.com/hazelcast/hazelcast-cloud-cli"
+      bin_path.install Dir["*"]
+      cd bin_path do
+        system "go", "build", "-ldflags", "-X github.com/hazelcast/hazelcast-cloud-cli/internal.Version=#{version} -X github.com/hazelcast/hazelcast-cloud-cli/internal.Distribution=BREW", "-o", bin/"hzcloud", "."
+      end
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
In this PR, we added hazelcast cloud cli formula since this is needed for the first time for [github action on hazelcast-cloud-cli ](https://github.com/hazelcast/hazelcast-cloud-cli/blob/master/.github/workflows/release.yml#L104) project. Also updated readme for additional detail for hzcloud