### PR TITLE
Preserve configuration files when upgrading

### DIFF
--- a/hazelcast@5.X.rb
+++ b/hazelcast@5.X.rb
@@ -16,9 +16,18 @@ class HazelcastAT5X < Formula
         end
         (bin/executable_name).write_env_script libexec/"bin/#{executable_name}", Language::Java.overridable_java_home_env
       end
+      etc.install "#{libexec}/config" => "hazelcast"
+      rm_rf libexec/"config"
+      libexec.install_symlink "#{etc}/hazelcast" => "config"
       prefix.install_metafiles
       inreplace libexec/"lib/hazelcast-download.properties", "hazelcastDownloadId=distribution", "hazelcastDownloadId=brew"
     end
+
+    def caveats
+        <<~EOS
+          Configuration files have been placed in #{etc}/hazelcast.
+        EOS
+      end
   
     def post_install
       exec "echo Hazelcast has been installed."

--- a/hazelcast@5.X.rb
+++ b/hazelcast@5.X.rb
@@ -27,7 +27,7 @@ class HazelcastAT5X < Formula
         <<~EOS
           Configuration files have been placed in #{etc}/hazelcast.
         EOS
-      end
+    end
   
     def post_install
       exec "echo Hazelcast has been installed."


### PR DESCRIPTION
Use `/usr/local/etc/hazelcast` for storing configuration files and symlink it in the installation directory in order to keep the changes between the upgrades.

During the upgrades, any modified file won't be overwritten but instead, a new file named *.default will be created

See: https://rubydoc.brew.sh/Formula#etc-instance_method


## Testing

### Verifing symlinks
- Created `ldziedziul/homebrew-hz` fork and pathed `hazelcast@5.0.1.rb` and `hazelcast@5.0.2.rb` with the changes from this commit then pushed to the remote
- Added tap: `brew tap ldziedziul/hz`
- Installed 5.0.1: `brew install hazelcast@5.0.1`
- Verified that `/usr/local/Cellar/hazelcast@5.0.1/5.0.1/libexec/config` is a symlink to `/usr/local/etc/hazelcast`
- Modified `/usr/local/etc/hazelcast/hazelcast.xml` and changed cluster-name to `dev-modified`
- Run the server and confirmed the `dev-modified` cluster name by calling `hz start`

### Verifing the configuration is used by newer versions
- Uninstall 5.0.1: `brew uninstall hazelcast@5.0.1`
- Verified that `/usr/local/etc/hazelcast` still exists
- Installed 5.0.2: `brew install hazelcast@5.0.2`
- Verified that `/usr/local/Cellar/hazelcast@5.0.2/5.0.2/libexec/config` is a symlink to `/usr/local/etc/hazelcast`
- Verified that the original config file from 5.0.2 is stored `/usr/local/etc/hazelcast/hazelcast.xml.default`
- Run the server and confirmed the `dev-modified` cluster name by calling `hz start`