### PR TITLE
Cleanup tap

### DIFF
--- a/Aliases/hazelcast-5.0
+++ b/Aliases/hazelcast-5.0
@@ -1,1 +1,0 @@
-../hazelcast@5.0.2.rb

--- a/Aliases/hazelcast-enterprise-5.0
+++ b/Aliases/hazelcast-enterprise-5.0
@@ -1,1 +1,0 @@
-../hazelcast-enterprise@5.0.2.rb

--- a/hazelcast-5.0.rb
+++ b/hazelcast-5.0.rb
@@ -1,10 +1,10 @@
-class HazelcastEnterprise52 < Formula
+class Hazelcast50 < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
-    url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.2-SNAPSHOT/hazelcast-enterprise-distribution-5.2-20220302.120523-20.tar.gz"
-    sha256 "88b351d28502d15332716b7a4aeca17a8efe9ec42c7d6bcf011bdf27ff14b547"
-    conflicts_with "hazelcast"
-  
+    url "https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.0.2/hazelcast-distribution-5.0.2.tar.gz"
+    sha256 "057dbbeb5fe1fb0ec77e4561e4dcf0f26ad917e1ade6f9ce8d232b5bb6a408cc"
+    conflicts_with "hazelcast-enterprise"
+
     depends_on "openjdk" => :recommended
 
     def install
@@ -28,7 +28,7 @@ class HazelcastEnterprise52 < Formula
           Configuration files have been placed in #{etc}/hazelcast.
         EOS
       end
-  
+
     def post_install
       exec "echo Hazelcast has been installed."
     end

--- a/hazelcast-enterprise-5.0.rb
+++ b/hazelcast-enterprise-5.0.rb
@@ -1,9 +1,9 @@
-class Hazelcast52 < Formula
+class HazelcastEnterprise50 < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
-    url "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.2-SNAPSHOT/hazelcast-distribution-5.2-20220302.111728-15.tar.gz"
-    sha256 "8a6f12c565a0bc5e111c76432f15bbc683120bb6edc32129cc3f351a18d9ab60"
-    conflicts_with "hazelcast-enterprise"
+    url "https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.0.2/hazelcast-enterprise-distribution-5.0.2.tar.gz"
+    sha256 "a0596e04e4c68be6537258a28f10cae886822882aff1214b0c2005b9555b6bd5"
+    conflicts_with "hazelcast"
   
     depends_on "openjdk" => :recommended
 

--- a/hazelcast-enterprise.rb
+++ b/hazelcast-enterprise.rb
@@ -1,8 +1,8 @@
 class HazelcastEnterprise < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
-    url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.2-SNAPSHOT/hazelcast-enterprise-distribution-5.2-20220302.120523-20.tar.gz"
-    sha256 "88b351d28502d15332716b7a4aeca17a8efe9ec42c7d6bcf011bdf27ff14b547"
+    url "https://repository.hazelcast.com/release/com/hazelcast/hazelcast-enterprise-distribution/5.1/hazelcast-enterprise-distribution-5.1.tar.gz"
+    sha256 "8eee7c86965186248013370d8b2983e90e085201a0b3960e8193165e54d5600a"
     conflicts_with "hazelcast"
   
     depends_on "openjdk" => :recommended

--- a/hazelcast.rb
+++ b/hazelcast.rb
@@ -1,8 +1,8 @@
 class Hazelcast < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
-    url "https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/5.2-SNAPSHOT/hazelcast-distribution-5.2-20220302.111728-15.tar.gz"
-    sha256 "8a6f12c565a0bc5e111c76432f15bbc683120bb6edc32129cc3f351a18d9ab60"
+    url "https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-distribution/5.1/hazelcast-distribution-5.1.tar.gz"
+    sha256 "8af0e906d1d33a8891660bd6233e91d55850b66a84313927f95056db202bace3"
     conflicts_with "hazelcast-enterprise"
   
     depends_on "openjdk" => :recommended


### PR DESCRIPTION
- Removed old symlink aliases
- Reset `hazelcast` and `hazelcast-enterprise` packages to stable releases
- Removed premature `-5.2` releases