### PR TITLE
Hazelcast Homebrew 5.8.0-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise-snapshot.rb
+++ b/hazelcast-enterprise-snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseSnapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "9b3f6478fc3c01e4e047790f8ca5b59368719fe97663c3202cc49677a60a9088"
+    sha256 "0eee71b5235a7ef2c8386034f49dae991ba7f3eae660dc5fa3ecf4946ba94279"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"

--- a/hazelcast-enterprise@5.8.0.snapshot.rb
+++ b/hazelcast-enterprise@5.8.0.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT580Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "9b3f6478fc3c01e4e047790f8ca5b59368719fe97663c3202cc49677a60a9088"
+    sha256 "0eee71b5235a7ef2c8386034f49dae991ba7f3eae660dc5fa3ecf4946ba94279"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.6.1", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/24272818317.