### PR TITLE
Hazelcast Homebrew 5.8.0-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise-snapshot.rb
+++ b/hazelcast-enterprise-snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseSnapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "fd2697738050513be5d496bbf9daee2acc181adb9fdc53acc67b5f08bf540c93"
+    sha256 "b527303395301d02bf238000f8e226ddbe3be60dd89bc37efa1561be324dd254"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
@@ -116,7 +116,7 @@ class HazelcastEnterpriseSnapshot < Formula
     conflicts_with "hazelcast-5.0", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast", because: "you can install only a single hazelcast or hazelcast-enterprise package"
 
-    depends_on "openjdk@21" => :recommended
+    depends_on "openjdk@25" => :recommended
 
     def install
       libexec.install Dir["*"]

--- a/hazelcast-enterprise@5.8.0.snapshot.rb
+++ b/hazelcast-enterprise@5.8.0.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT580Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "fd2697738050513be5d496bbf9daee2acc181adb9fdc53acc67b5f08bf540c93"
+    sha256 "b527303395301d02bf238000f8e226ddbe3be60dd89bc37efa1561be324dd254"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.6.1", because: "you can install only a single hazelcast or hazelcast-enterprise package"
@@ -116,7 +116,7 @@ class HazelcastEnterpriseAT580Snapshot < Formula
     conflicts_with "hazelcast-5.0", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast", because: "you can install only a single hazelcast or hazelcast-enterprise package"
 
-    depends_on "openjdk@21" => :recommended
+    depends_on "openjdk@25" => :recommended
 
     def install
       libexec.install Dir["*"]


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/24543585135.