### PR TITLE
Hazelcast Homebrew 5.8.0-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise-snapshot.rb
+++ b/hazelcast-enterprise-snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseSnapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "a77ee69b1d8c956893bea31330e92af278e0c4383ba484181f9e4446ae3f9d6b"
+    sha256 "f7dc17108365035a4d85560c6b84541745b9045eea652ae362fdbbef172703d9"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"

--- a/hazelcast-enterprise@5.8.0.snapshot.rb
+++ b/hazelcast-enterprise@5.8.0.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT580Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.8.0-SNAPSHOT/hazelcast-enterprise-distribution-5.8.0-SNAPSHOT.tar.gz"
-    sha256 "a77ee69b1d8c956893bea31330e92af278e0c4383ba484181f9e4446ae3f9d6b"
+    sha256 "f7dc17108365035a4d85560c6b84541745b9045eea652ae362fdbbef172703d9"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/26612521731/job/78421303427.