### PR TITLE
Hazelcast Homebrew 5.4.6-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.4.6.snapshot.rb
+++ b/hazelcast-enterprise@5.4.6.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT546Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.4.6-SNAPSHOT/hazelcast-enterprise-distribution-5.4.6-SNAPSHOT.tar.gz"
-    sha256 "91fe844a081875197f4b9b7fad159c1adfb0eb850c9e26b36f201ae1a860e35c"
+    sha256 "2ba33ba77b1efd81e84d7a921189e6a9a8f659ace1895fdb793ff9b62917f696"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/26670442412/job/78612825215.