### PR TITLE
Hazelcast Homebrew 5.5.10-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.5.10.snapshot.rb
+++ b/hazelcast-enterprise@5.5.10.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT5510Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.10-SNAPSHOT/hazelcast-enterprise-distribution-5.5.10-SNAPSHOT.tar.gz"
-    sha256 "6dd718dc46f56ba87a18c1d4d9df1bb5fa70186e37d2c683ec0bc6a8da883530"
+    sha256 "82e3c8e1d8d2910f158cebf03767dfdecf4d4b1d062881e1a071dfb94c463862"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/26858611848/job/79207514955.