### PR TITLE
Hazelcast Homebrew 5.4.5-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.4.5.snapshot.rb
+++ b/hazelcast-enterprise@5.4.5.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT545Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.4.5-SNAPSHOT/hazelcast-enterprise-distribution-5.4.5-SNAPSHOT.tar.gz"
-    sha256 "27877713440853de0b2d7c447d394266ef45bb0e1fdfb8a90df7564f5d0a9acc"
+    sha256 "592875abe4b38caf244b7498e2878c22db2fe78741c9e4c1db11cbe710b54a7b"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/27317700889/job/80701836342.