### PR TITLE
Hazelcast Homebrew 5.7.1-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.7.1.snapshot.rb
+++ b/hazelcast-enterprise@5.7.1.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT571Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.7.1-SNAPSHOT/hazelcast-enterprise-distribution-5.7.1-SNAPSHOT.tar.gz"
-    sha256 "967ecc6b3d13d8de2511b64b63a3c5eb63a378828a5e9b137aaeab97f2e2f001"
+    sha256 "d9d8d787f582d428e118c541d11f65119d479f688f869692acc5f6e81e49dcf3"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/27659900717/job/81802010679.