### PR TITLE
Hazelcast Homebrew 5.6.2-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.6.2.snapshot.rb
+++ b/hazelcast-enterprise@5.6.2.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT562Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.6.2-SNAPSHOT/hazelcast-enterprise-distribution-5.6.2-SNAPSHOT.tar.gz"
-    sha256 "b67075abe68abb1a153464bd0520edfa59f29817ce42445b3a5b1906a7dbc126"
+    sha256 "15acf568c8fa1e0098ce7146506c4ca75b57c5033aa6775f325d67182929d9ae"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/27730892766/job/82037555308.