### PR TITLE
Hazelcast Homebrew 5.6.2-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.6.2.snapshot.rb
+++ b/hazelcast-enterprise@5.6.2.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT562Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.6.2-SNAPSHOT/hazelcast-enterprise-distribution-5.6.2-SNAPSHOT.tar.gz"
-    sha256 "548e097b0f0708422d5e6398f76effe1dee6ffee97e70f74ae57e029373761b2"
+    sha256 "ac8f405e4553cba2668a49c61f11e832ce5c34f2db77963d3fbb427e032b7a99"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/28487395277/job/84436722257.