### PR TITLE
Hazelcast Homebrew 5.5.10-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.5.10.snapshot.rb
+++ b/hazelcast-enterprise@5.5.10.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT5510Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.10-SNAPSHOT/hazelcast-enterprise-distribution-5.5.10-SNAPSHOT.tar.gz"
-    sha256 "8f516512dec81cf92da31b4028c0874d1d5e1f68757535b929a45ac674682ea2"
+    sha256 "333a055cbaf9fc3f5e7d7de8779b372f28a702f71b1303b396e599edb0b076c6"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/28487558873/job/84437875133.