### PR TITLE
Hazelcast Homebrew 5.5.11-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.5.11.snapshot.rb
+++ b/hazelcast-enterprise@5.5.11.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT5511Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.11-SNAPSHOT/hazelcast-enterprise-distribution-5.5.11-SNAPSHOT.tar.gz"
-    sha256 "dbfa4a2fc07ed325e7aeb488d37a0f038ade3cdf9721d7348867d4e1ef08bf0e"
+    sha256 "56dbf374ec80a0a1cbd5deb2986d29dc20a64e023534d64171f82f8cd26c7581"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/28632136842/job/84911296878.