### PR TITLE
Hazelcast Homebrew 5.7.1-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.7.1.snapshot.rb
+++ b/hazelcast-enterprise@5.7.1.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT571Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.7.1-SNAPSHOT/hazelcast-enterprise-distribution-5.7.1-SNAPSHOT.tar.gz"
-    sha256 "a55d59867175de3cb70f29a209e0f534e1a3003551658e47007f9a5390671ba7"
+    sha256 "f21fbe8b0c8bd9824c868af4a984eab71511783509df7b55be43b62f27212c32"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/28987178417/job/86018854966.