### PR TITLE
Hazelcast Homebrew 5.6.2-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.6.2.snapshot.rb
+++ b/hazelcast-enterprise@5.6.2.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT562Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.6.2-SNAPSHOT/hazelcast-enterprise-distribution-5.6.2-SNAPSHOT.tar.gz"
-    sha256 "8554d40856793b82de4d24da62423404b5b8b5c1a0a7e91bc254e56aa2bef44d"
+    sha256 "0eff9406b73b6313df6737acf7ccec13763d394ef680f4c9acc506a3ce751f70"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/29061832913/job/86265224431.