### PR TITLE
Hazelcast Homebrew 5.5.11-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.5.11.snapshot.rb
+++ b/hazelcast-enterprise@5.5.11.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT5511Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.11-SNAPSHOT/hazelcast-enterprise-distribution-5.5.11-SNAPSHOT.tar.gz"
-    sha256 "4d0c1ad73ec283ccfc2e6f1fe57a446462a1272ddedf61bfc1ecb93a1b6b3fae"
+    sha256 "4861ded5f7bf6baacb2fbe3b9dd260761ae1a12b903cecaff32329b12926a384"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/29297838143/job/86975818812.