### PR TITLE
Hazelcast Homebrew 5.6.2-SNAPSHOT hazelcast-enterprise release

### DIFF
--- a/hazelcast-enterprise@5.6.2.snapshot.rb
+++ b/hazelcast-enterprise@5.6.2.snapshot.rb
@@ -2,7 +2,7 @@ class HazelcastEnterpriseAT562Snapshot < Formula
     desc "Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service."
     homepage "https://github.com/hazelcast/hazelcast-command-line"
     url "https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.6.2-SNAPSHOT/hazelcast-enterprise-distribution-5.6.2-SNAPSHOT.tar.gz"
-    sha256 "6264406080dd791a69b8c69e0b0e9d5d156984b8735afb17b06200debb005ac2"
+    sha256 "c17a9d3d8fb694d5c9aa294ee8afa4dd94531b0c148ea7627c20d1a60a6be344"
     conflicts_with "hazelcast-enterprise@6.0.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.8.0.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"
     conflicts_with "hazelcast-enterprise@5.7.1.snapshot", because: "you can install only a single hazelcast or hazelcast-enterprise package"


### PR DESCRIPTION
Generated by https://github.com/hazelcast/hazelcast-packaging/actions/runs/29624454573/job/88025960944.